### PR TITLE
Fix example to properly reference 'user' table rather than non-existant 'users'

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -75,7 +75,7 @@ class UserItem(db.Model):
     #__tablename__ = 'user_item'
 
     _id = Column(types.Integer(), primary_key=True)
-    user_id = Column(types.Integer(), ForeignKey('users._id'))
+    user_id = Column(types.Integer(), ForeignKey('user._id'))
     name = Column(types.String())
 
     user = orm.relationship('User')


### PR DESCRIPTION
The example in index.md incorrectly references `users._id`. The actual table attribute is `user._id`. Small change but has a big impact on those following the docs (i.e. first example doesn't work)
