### PR TITLE
Made __table_args__ & __mapper_args__ recursive functions.

### DIFF
--- a/alchy/utils.py
+++ b/alchy/utils.py
@@ -39,11 +39,8 @@ def has_primary_key(metadict):
 
 def camelcase_to_underscore(string):
     """Convert string from ``CamelCase`` to ``under_score``."""
-    regex_first_cap = re.compile('(.)([A-Z][a-z]+)')
-    regex_all_cap = re.compile('([a-z0-9])([A-Z])')
-
-    first_cap = regex_first_cap.sub(r'\1_\2', string)
-    return regex_all_cap.sub(r'\1_\2', first_cap).lower()
+    return re.sub('((?<=[a-z0-9])[A-Z]|(?!^)[A-Z](?=[a-z]))', r'_\1',
+                  string).lower()
 
 
 def iterflatten(items):
@@ -76,3 +73,21 @@ def mapper_class(relation):
 def get_mapper_class(model, field):
     """Return mapper class given ORM model and field string."""
     return mapper_class(getattr(model, field))
+
+
+def process_args(cls, attr, out_args, out_kwargs):
+    """Store specified tuple/dict attribute in out_args and/or out_kwargs."""
+    try:
+        args = getattr(cls, attr)
+    except AttributeError:
+        return
+    if not args:
+        return
+    if isinstance(args, dict):  # it's a dictionary
+        out_kwargs.update(args)
+    else:  # it's a tuple or list
+        if isinstance(args[-1], dict):  # it has a dictionary at the end
+            out_args.extend([arg for arg in args[:-1] if arg not in out_args])
+            out_kwargs.update(args[-1])
+        else:
+            out_args.extend([arg for arg in args if arg not in out_args])

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,5 +1,5 @@
 
-from sqlalchemy import orm, types, Column, ForeignKey
+from sqlalchemy import orm, types, Column, ForeignKey, Index
 from sqlalchemy.ext.hybrid import hybrid_property
 
 from alchy import model, query
@@ -97,6 +97,8 @@ class Baz(Model):
     def hybrid_number(self, n):
         self.number = n / n
 
+    __local_table_args__ = {'mysql_engine': 'InnoDB'}
+
 
 class Qux(Model):
     __tablename__ = 'qux'
@@ -109,10 +111,15 @@ class Qux(Model):
     foo = orm.relationship('Foo')
     doz = orm.relationship('Doz', uselist=False)
 
+    __local_table_args__ = (Index('idx_number', 'number'),)
+
 
 class Doz(Model):
     qux_id = Column(types.Integer(), ForeignKey('qux._id'), primary_key=True)
     name = Column(types.String())
+
+    __local_table_args__ = (Index('idx_name', 'name'),
+                            {'mysql_engine': 'InnoDB'})
 
 
 class OrderStatus(DeclarativeEnum):
@@ -121,10 +128,18 @@ class OrderStatus(DeclarativeEnum):
     complete = ('c', 'Complete')
 
 
+class OrderSide(DeclarativeEnum):
+    buy = ('b', 'Buy')
+    sell = ('s', 'Sell')
+    __enum_args__ = {'name': 'ck_order_side_constraint',
+                     'inherit_schema': True}
+
+
 class Order(Model):
     __tablename__ = 'orders'
     _id = Column(types.Integer(), primary_key=True)
     status = Column(OrderStatus.db_type(), default=OrderStatus.pending)
+    side = Column(OrderSide.db_type(), default=OrderSide.buy)
 
 
 class AutoGenTableName(Model):
@@ -175,7 +190,8 @@ class Search(Model):
     _id = Column(types.Integer(), primary_key=True)
     string = Column(types.String())
     search_one_id = Column(types.Integer(), ForeignKey('search_one._id'))
-    status = Column(OrderStatus.db_type(), default=OrderStatus.pending)
+    status = Column(OrderStatus.db_type(name='ck_order_status_check_name'),
+                    default=OrderStatus.pending)
 
     many = orm.relationship('SearchMany')
     one = orm.relationship('SearchOne')

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -4,7 +4,7 @@ import pickle
 import sqlalchemy
 
 from .base import TestQueryBase
-from .fixtures import OrderStatus, Order
+from .fixtures import OrderStatus, OrderSide, Order
 
 
 class TestDeclarativeEnum(TestQueryBase):
@@ -20,7 +20,12 @@ class TestDeclarativeEnum(TestQueryBase):
         self.assertTrue(hasattr(test_order.status, 'value'))
         self.assertTrue(hasattr(test_order.status, 'description'))
 
+        self.assertTrue(hasattr(test_order.side, 'name'))
+        self.assertTrue(hasattr(test_order.side, 'value'))
+        self.assertTrue(hasattr(test_order.side, 'description'))
+
         test_order.status = OrderStatus.pending
+        test_order.side = OrderSide.sell
         self.db.add_commit(test_order)
 
         self.assertEqual(test_order.status.name, 'pending')
@@ -30,17 +35,30 @@ class TestDeclarativeEnum(TestQueryBase):
         self.assertEqual(str(test_order.status), 'pending')
         self.assertEqual(repr(test_order.status), '<pending>')
 
+        self.assertEqual(test_order.side.name, 'sell')
+        self.assertEqual(test_order.side.value, 's')
+        self.assertEqual(test_order.side.description, 'Sell')
+
+        self.assertEqual(str(test_order.side), 'sell')
+        self.assertEqual(repr(test_order.side), '<sell>')
+
     def test_pickle(self):
         status = OrderStatus.complete
-
         pickled = pickle.dumps(status)
         unpickled = pickle.loads(pickled)
-
         self.assertIs(unpickled, status)
+
+        side = OrderSide.buy
+        pickled = pickle.dumps(side)
+        unpickled = pickle.loads(pickled)
+        self.assertIs(unpickled, side)
 
     def test_from_string(self):
         self.assertIs(OrderStatus.from_string('p'), OrderStatus.pending)
         self.assertRaises(ValueError, OrderStatus.from_string, 'invalid')
+
+        self.assertIs(OrderSide.from_string('b'), OrderSide.buy)
+        self.assertRaises(ValueError, OrderSide.from_string, 'invalid')
 
     def test_iter_support(self):
         self.assertTrue(len(list(OrderStatus)) > 0)
@@ -51,7 +69,19 @@ class TestDeclarativeEnum(TestQueryBase):
                 OrderStatus.from_string(status.value),
                 getattr(OrderStatus, status.name))
 
+        self.assertTrue(len(list(OrderSide)) > 0)
+
+        for side in OrderSide:
+            self.assertTrue(hasattr(OrderSide, side.name))
+            self.assertIs(
+                OrderSide.from_string(side.value),
+                getattr(OrderSide, side.name))
+
     def test_to_dict(self):
         self.assertEqual(
             OrderStatus.pending.to_dict(),
             {'value': 'p', 'description': 'Pending'})
+
+        self.assertEqual(
+            OrderSide.sell.to_dict(),
+            {'value': 's', 'description': 'Sell'})


### PR DESCRIPTION
A few things.
1. I followed the recipe in http://stackoverflow.com/questions/23415638/combining-table-args-with-constraints-from-mixin-classes-in-sqlalchemy to define `__table_args__` and `__mapper_args__` in `ModelBase`, though had to modify it to avoid infinite loops. I also have no idea if any of this should go in `ModelMeta` instead. I haven't added any tests.
2. I cleaned up the `and field in update_fields` business.
3. I changed `camelcase_to_underscore()` to use a single regular expression, per the second comment in http://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-camel-case. Not only is it shorter, it's also about 20% faster. It produces identical results.
4. I added `__enum_args__` and `name` support to `DeclarativeEnum{Type}`.
