### PR TITLE
camelcase_to_underscore() should not duplicate underscores.

### DIFF
--- a/alchy/model.py
+++ b/alchy/model.py
@@ -41,9 +41,9 @@ class ModelMeta(DeclarativeMeta):
         # Determine if primary key is defined for dct or any of its bases.
         base_dcts = [dct] + [base.__dict__ for base in bases]
 
-        if (not dct.get('__tablename__')
-                and dct.get('__table__') is None
-                and any([has_primary_key(base) for base in base_dcts])):
+        if (not dct.get('__tablename__') and
+                dct.get('__table__') is None and
+                any([has_primary_key(base) for base in base_dcts])):
             # Set to underscore version of class name.
             dct['__tablename__'] = camelcase_to_underscore(name)
 
@@ -186,10 +186,10 @@ class ModelBase(object):
 
         attr = getattr(self, field)
 
-        if (hasattr(attr, 'update')
-                and value
-                and is_dict
-                and not isinstance(attr, dict)):
+        if (hasattr(attr, 'update') and
+                value and
+                is_dict and
+                not isinstance(attr, dict)):
             # Nest calls to attr.update.
             attr.update(value)
         else:

--- a/alchy/utils.py
+++ b/alchy/utils.py
@@ -25,9 +25,9 @@ def is_sequence(obj):
     """Test if `obj` is an iterable but not ``dict`` or ``str``. Mainly used to
     determine if `obj` can be treated like a ``list`` for iteration purposes.
     """
-    return (isinstance(obj, Iterable)
-            and not isinstance(obj, string_types)
-            and not isinstance(obj, dict))
+    return (isinstance(obj, Iterable) and
+            not isinstance(obj, string_types) and
+            not isinstance(obj, dict))
 
 
 def has_primary_key(metadict):
@@ -39,8 +39,8 @@ def has_primary_key(metadict):
 
 def camelcase_to_underscore(string):
     """Convert string from ``CamelCase`` to ``under_score``."""
-    return (re.sub('((?<=[a-z0-9])[A-Z]|(?!^)[A-Z](?=[a-z]))', r'_\1', string)
-            .lower())
+    return re.sub('((?<=[a-z0-9])[A-Z]|(?<!_)(?!^)[A-Z](?=[a-z]))', r'_\1',
+                  string).lower()
 
 
 def iterflatten(items):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -78,8 +78,8 @@ class TestEvents(TestEventsBase):
         @events.on_set('name', retval=True)
         def on_set_name(target, value, oldvalue, initator):
             if oldvalue is None or (
-                    hasattr(oldvalue, '__class__')
-                    and oldvalue.__class__.__name__ == 'symbol'):
+                    hasattr(oldvalue, '__class__') and
+                    oldvalue.__class__.__name__ == 'symbol'):
                 # oldvalue is a symbol for either NO_VALUE or NOT_SET so allow
                 # update
                 return value


### PR DESCRIPTION
Existing behavior:
```
In [1]: from alchy.utils import camelcase_to_underscore

In [2]: camelcase_to_underscore('HelloThere_Hello_There_HELLO_There_HELLO_THERE_HELLOThere')
Out[2]: 'hello_there__hello__there_hello__there_hello_there_hello_there'
```

Desired ``Out[2]``:
```
Out[2]: 'hello_there_hello_there_hello_there_hello_there_hello_there'
```

The proposed change appears to accomplish this, though I have to admit I'm not a regular-expressions expert, so it's possible I'm missing some complication.

Also removed line breaks before binary operators.