### PR TITLE
Fixed handling of __table_args__ and __mapper_args__.

### DIFF
--- a/alchy/_compat.py
+++ b/alchy/_compat.py
@@ -102,3 +102,9 @@ if hasattr(sys, 'pypy_version_info'):
         BROKEN_PYPY_CTXMGR_EXIT = True
     except AssertionError:
         pass
+
+# Define classmethod_func(f) to retrieve the unbound function of classmethod f
+if sys.version_info[:2] >= (2, 7):
+    def classmethod_func(f): return f.__func__
+else:
+    def classmethod_func(f): return f.__get__(1).im_func

--- a/alchy/model.py
+++ b/alchy/model.py
@@ -15,7 +15,7 @@ from .utils import (
     camelcase_to_underscore,
     get_mapper_class,
     merge_declarative_args,
-    unique
+    unique,
 )
 from ._compat import iteritems
 
@@ -126,9 +126,13 @@ class ModelBase(object):
     @declared_attr
     def __table_args__(cls):  # pylint: disable=no-self-argument
         # pylint: disable=no-member
-        args, kargs = merge_declarative_args(cls.__bases__, '__table_args__')
+        args, kargs = merge_declarative_args(cls,
+                                             [base for base in cls.__bases__ if
+                                              not isinstance(base, ModelBase)],
+                                             '__table_args__',
+                                             inherited=True)
         local_args, local_kargs = merge_declarative_args(
-            [cls], '__local_table_args__')
+                cls, cls.mro(), '__local_table_args__', inherited=False)
 
         args = unique(args + local_args)
         kargs.update(local_kargs)
@@ -142,9 +146,12 @@ class ModelBase(object):
     def __mapper_args__(cls):  # pylint: disable=no-self-argument
         # pylint: disable=no-member
         # NOTE: Mapper args are only allowed to be a dict so we ignore `args`.
-        _, kargs = merge_declarative_args(cls.__bases__, '__mapper_args__')
-        _, local_kargs = merge_declarative_args([cls],
-                                                '__local_mapper_args__')
+        _, kargs = merge_declarative_args(cls,
+                                          [base for base in cls.__bases__ if
+                                           not isinstance(base, ModelBase)],
+                                          '__mapper_args__', inherited=True)
+        _, local_kargs = merge_declarative_args(
+                cls, cls.mro(), '__local_mapper_args__', inherited=False)
 
         kargs.update(local_kargs)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -427,14 +427,14 @@ class TestModel(TestQueryBase):
             string = Column(types.String())
             number = Column(types.Integer())
 
-            __table_args__ = (Index('idx_abstract_string', 'string'),
-                              Index('idx_abstract_number', 'number'),
-                              {'mysql_foo': 'bar', 'mysql_bar': 'bar'})
+            __local_table_args__ = (Index('idx_abstract_string', 'string'),
+                                    Index('idx_abstract_number', 'number'),
+                                    {'mysql_foo': 'bar', 'mysql_bar': 'bar'})
 
         class Mixin(object):
             name = Column(types.String())
 
-            __table_args__ = (Index('idx_name', 'name'),)
+            __local_table_args__ = (Index('idx_name', 'name'),)
 
         class Obj(Model, Mixin, Abstract):
             text = Column(types.Text())
@@ -459,14 +459,15 @@ class TestModel(TestQueryBase):
             string = Column(types.String())
             number = Column(types.Integer())
 
-            __table_args__ = (Index('idx_cm_abstract_string', 'string'),
-                              Index('idx_cm_abstract_number', 'number'),
-                              {'mysql_foo': 'bar', 'mysql_bar': 'bar'})
+            __local_table_args__ = (Index('idx_cm_abstract_string', 'string'),
+                                    Index('idx_cm_abstract_number', 'number'),
+                                    {'mysql_foo': 'bar', 'mysql_bar': 'bar'})
 
         class MixinCM(object):
             name = Column(types.String())
 
-            __table_args__ = (Index('idx_cm_name', 'name'),)
+            def __local_table_args__():
+                return (Index('idx_cm_name', 'name'),)
 
         class ObjCM(Model, MixinCM, AbstractCM):
             text = Column(types.Text())
@@ -494,12 +495,13 @@ class TestModel(TestQueryBase):
             string = Column(types.String())
             number = Column(types.Integer())
 
-            __mapper_args__ = {'column_prefix': '_', 'order_by': 'number'}
+            __local_mapper_args__ = {'column_prefix': '_',
+                                     'order_by': 'number'}
 
         class Mixin(object):
             name = Column(types.String())
 
-            __mapper_args__ = {'column_prefix': '__'}
+            __local_mapper_args__ = {'column_prefix': '__'}
 
         class Obj2(Model, Mixin, Abstract):
             text = Column(types.Text())


### PR DESCRIPTION
I changed slightly the way ``ModelBase.__table_args__`` and ``ModelBase.__mapper_args__`` work. Previously, when invoked for a (derived) class ``cls``, they would merge ``base.__{table/mapper}_args__`` from ``cls.__bases__`` with ``cls.__local_{table/mapper}_args__``. The problem with this is that if any intermediate subclass of ``ModelBase`` (or any mixin that is inherited by ``cls`` ahead of ``ModelBase``) sets ``__{table/mapper}_args__`` , then the ``ModelBase.__{table/mapper}_args__`` won't be invoked at all, so no merging will happen. The new behavior is to merge ``base.__local_{table/mapper}_args__`` from all ``cls.__mro__``. This way ``ModelBase.__{table/mapper}_args__`` is never overridden, so the merging can always happen.