### PR TITLE
Replace __local_mapper/table_args__ with __merge_mapper/table_args__.

### DIFF
--- a/alchy/model.py
+++ b/alchy/model.py
@@ -11,7 +11,7 @@ from .utils import (
     camelcase_to_underscore,
     get_mapper_class,
     merge_mapper_args,
-    merge_table_args
+    merge_table_args,
 )
 from ._compat import iteritems
 
@@ -68,16 +68,16 @@ class ModelMeta(DeclarativeMeta):
 
             events.register(cls, dct)
 
-        base_dcts = [dct] + [base.__dict__ for base in bases]
-
         # Merge __mapper_args__ from all base classes.
-        __mapper_args__ = merge_mapper_args(cls, base_dcts)
+        __mapper_args_configs__, __mapper_args__ = merge_mapper_args(cls)
         if __mapper_args__:
+            cls.__mapper_args_configs__ = __mapper_args_configs__
             cls.__mapper_args__ = __mapper_args__
 
         # Merge __table_args__ from all base classes.
-        __table_args__ = merge_table_args(cls, base_dcts)
+        __table_args_configs__, __table_args__ = merge_table_args(cls)
         if __table_args__:
+            cls.__table_args_configs__ = __table_args_configs__
             cls.__table_args__ = __table_args__
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -438,7 +438,7 @@ class TestModel(TestQueryBase):
 
         class Obj(Model, Mixin, Abstract):
             text = Column(types.Text())
-            __local_table_args__ = (Index('idx_obj_text', 'text'),
+            __merge_table_args__ = (Index('idx_obj_text', 'text'),
                                     {'mysql_foo': 'foo'})
 
         self.assertEqual(Obj.__table_args__[-1],
@@ -473,7 +473,7 @@ class TestModel(TestQueryBase):
             text = Column(types.Text())
 
             @classmethod
-            def __local_table_args__(cls):
+            def __merge_table_args__(cls):
                 return (Index('idx_cm_obj_text', 'text'),
                         {'mysql_foo': 'foo'})
 
@@ -504,7 +504,7 @@ class TestModel(TestQueryBase):
 
         class Obj2(Model, Mixin, Abstract):
             text = Column(types.Text())
-            __local_mapper_args__ = {'order_by': 'string'}
+            __merge_mapper_args__ = {'order_by': 'string'}
 
         self.assertEqual(Obj2.__mapper_args__,
                          {'column_prefix': '__', 'order_by': 'string'})


### PR DESCRIPTION
This is my attempt at fixing the logic for merging ``__mapper/table_args__`` from base classes.

In the absence of callables, the logic for setting ``cls.__mapper/table_args__`` is straightforward:
- if ``cls.__dict__`` specifies ``'__mapper/table_args__'``, then simply use that;
- otherwise, merge ``cls.__dict__['__merge_mapper/table_args__']`` (if any) with the recursive calculation of ``__mapper/table_args__`` for every base ``base in cls.__bases__``.

In the case that any of the base ``__mapper/table_args__`` are constructed from callables (e.g. classmethods), such callables are reevaluated for ``cls``.