### PR TITLE
Allow make_declarative_base to take a custom metaclass as input. 

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,3 +12,4 @@ Contributors
 
 - Jeff Knupp, http://www.jeffknupp.com/,  `jeffknupp@github <https://github.com/jeffknupp>`_
 - Seth P., `seth-p@github <https://github.com/seth-p>`_
+- Eli Chan, eli.d.chan@gmail.com, `elidchan@github <https://github.com/elidchan>`_

--- a/alchy/model.py
+++ b/alchy/model.py
@@ -404,15 +404,16 @@ class ModelBase(object):
         return inspect(cls).columns.keys()
 
 
-def make_declarative_base(session=None, Model=None, Base=None):
+def make_declarative_base(session=None, Model=None, Base=None, Meta=None):
     """Factory function for either creating a new declarative base class or
     extending a previously defined one.
     """
     if Model is None:
         Base = Base or ModelBase
+        Meta = Meta or ModelMeta
         Model = declarative_base(cls=Base,
                                  constructor=Base.__init__,
-                                 metaclass=ModelMeta)
+                                 metaclass=Meta)
 
     extend_declarative_base(Model, session)
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -132,7 +132,7 @@ Fetch model and operate.
     user.flush()
 
     # access the session that loaded the model instance
-    user.session == db.object_session(user)
+    assert user.session() == db.object_session(user)
 
     # delete user
     user.delete()


### PR DESCRIPTION
Any custom metaclass should extend ModelMeta, of course.