### PR TITLE
Implemented late initialisation for the Manager

### DIFF
--- a/alchy/manager.py
+++ b/alchy/manager.py
@@ -44,7 +44,6 @@ from .query import QueryModel
 from .session import Session
 from ._compat import string_types, itervalues
 
-
 __all__ = [
     'ManagerMixin',
     'Manager',
@@ -115,11 +114,20 @@ class Manager(ManagerMixin):
     your subclass will inherit the functionality of :class:`alchy.Session`.
     """
 
-    def __init__(self,
-                 config=None,
-                 session_options=None,
-                 Model=None,
-                 session_class=None):
+    def __init__(self, config=None, session_options=None, Model=None, session_class=None):
+        self.config = None
+        self._engines = {}
+        self._binds = {}
+        self.session_class = None
+        self.session = None
+        self.Model = None
+
+        # If the manager had any arguments passed during the declaration (i.e: Manager()) then init it
+        # otherwise, it's a late bind.
+        if config is not None or session_options is not None or Model is not None or session_class is not None:
+            self.init(config=config, session_options=session_options, Model=Model, session_class=session_class)
+
+    def init(self, config=None, session_options=None, Model=None, session_class=None):
 
         #: Database engine configuration options.
         self.config = Config(defaults={
@@ -136,9 +144,6 @@ class Manager(ManagerMixin):
             self.config.update(config)
         elif config is not None:
             self.config.from_object(config)
-
-        self._engines = {}
-        self._binds = {}
 
         if session_options is None:
             session_options = {}
@@ -287,6 +292,7 @@ class Config(dict):
     """Configuration loader which acts like a dict but supports loading
     values from an object limited to ``ALL_CAPS_ATTRIBUTES``.
     """
+
     def __init__(self, defaults=None):
         super(Config, self).__init__(defaults or {})
 

--- a/alchy/manager.py
+++ b/alchy/manager.py
@@ -114,7 +114,8 @@ class Manager(ManagerMixin):
     your subclass will inherit the functionality of :class:`alchy.Session`.
     """
 
-    def __init__(self, config=None, session_options=None, Model=None, session_class=None):
+    def __init__(self, config=None, session_options=None,
+                 Model=None, session_class=None):
         self.config = None
         self._engines = {}
         self._binds = {}
@@ -122,12 +123,19 @@ class Manager(ManagerMixin):
         self.session = None
         self.Model = None
 
-        # If the manager had any arguments passed during the declaration (i.e: Manager()) then init it
+        # If the manager had any arguments passed during the
+        # declaration (i.e: Manager()) then init it
         # otherwise, it's a late bind.
-        if config is not None or session_options is not None or Model is not None or session_class is not None:
-            self.init(config=config, session_options=session_options, Model=Model, session_class=session_class)
+        if config is not None or session_options is not None \
+                or Model is not None or session_class is not None:
+            self.init(
+                config=config,
+                session_options=session_options,
+                Model=Model,
+                session_class=session_class)
 
-    def init(self, config=None, session_options=None, Model=None, session_class=None):
+    def init(self, config=None, session_options=None,
+             Model=None, session_class=None):
 
         #: Database engine configuration options.
         self.config = Config(defaults={

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,4 +1,3 @@
-
 import os
 import glob
 
@@ -14,7 +13,6 @@ from .fixtures import Foo
 
 
 class TestManager(TestBase):
-
     def test_create_drop_all(self):
         db = manager.Manager(Model=fixtures.Model, config=self.config)
 
@@ -43,8 +41,39 @@ class TestManager(TestBase):
         self.assertRaises(UnmappedError, db.drop_all)
 
 
-class TestManagerSessionExtensions(TestQueryBase):
+class TestManagerLateInitialization(TestBase):
+    def test_create_drop_all(self):
+        db = manager.Manager()
+        db.init(Model=fixtures.Model, config=self.config)
 
+        db.create_all()
+
+        self.assertTrue(len(self.models) > 0)
+        self.assertModelTablesExist(db.engine)
+
+        db.drop_all()
+
+        self.assertModelTablesNotExists(db.engine)
+
+    def test_default_model_config(self):
+        db = manager.Manager()
+        db.init(config=self.config)
+        self.assertTrue(issubclass(db.Model, model.ModelBase))
+
+    def test_create_all_exception(self):
+        # pass in dummy value for Model
+        db = manager.Manager()
+        db.init(Model=False, config=self.config)
+        self.assertRaises(UnmappedError, db.create_all)
+
+    def test_drop_all_exception(self):
+        # pass in dummy value for Model
+        db = manager.Manager()
+        db.init(Model=False, config=self.config)
+        self.assertRaises(UnmappedError, db.drop_all)
+
+
+class TestManagerSessionExtensions(TestQueryBase):
     def get_count(self, table='foo'):
         return self.db.execute(
             'select count(*) from {0}'.format(table)).scalar()


### PR DESCRIPTION
I stumbled across Alchy after having used SqlAlchemy with Flask-Sqlalchemy and wanted something similar for a non-flask project through work.

The only issue I found, was having a 'late-bind' sort of feature, where in Flask-Sqlalchemy there is the 'init_app()' method.

This is my take on that approach, in a much more straightforward, and direct approach.

It changes nothing under the hood, and assuming it's used responsibly it's a painless feature.

If there's anything I can do to improve this, or further solidify it then please let me know!
